### PR TITLE
README : Made obsolete by couch_peruser option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Note : Obsolete as of CouchDB 2.1.1
+
+You can now enable this in CouchDB using the built-in [couch_peruser](https://docs.couchdb.org/en/latest/config/couch-peruser.html) option.
+
 couchperuser
 ============
 


### PR DESCRIPTION
This message should save time for those who get here by searching. I somehow didn't see the option in CouchDB docs, and had I not seen the issue in this repo I would have gone down a rabbit-hole trying to get this code to work.

Closes #18.

